### PR TITLE
fix: .podspec and Spec name renamed

### DIFF
--- a/DootixDeveloperPhotoviewer.podspec
+++ b/DootixDeveloperPhotoviewer.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapacitorCommunityPhotoviewer'
+  s.name = 'DootixDeveloperPhotoviewer'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "CapacitorCommunityPhotoviewer.podspec"
+    "DootixDeveloperPhotoviewer.podspec"
   ],
   "author": "Jean Pierre Quéau",
   "license": "MIT",


### PR DESCRIPTION
Related with this [issue](https://github.com/dootixsa/photoviewer/issues/1)

I have changed the name of the .podspec to avoid the error No Podspec found when doing `npx cap sync`.